### PR TITLE
Support dual firmware (aka A/B) devices where rootfs_data are discreete partitions

### DIFF
--- a/libfstools/common.c
+++ b/libfstools/common.c
@@ -3,8 +3,7 @@
 #include "common.h"
 #define BUFLEN 128
 
-int
-read_uint_from_file(char *dirname, char *filename, unsigned int *i)
+int read_uint_from_file(char *dirname, char *filename, unsigned int *i)
 {
 	FILE *f;
 	char fname[BUFLEN];
@@ -23,8 +22,7 @@ read_uint_from_file(char *dirname, char *filename, unsigned int *i)
 	return ret;
 }
 
-char
-*read_string_from_file(const char *dirname, const char *filename, char *buf, size_t bufsz)
+char *read_string_from_file(const char *dirname, const char *filename, char *buf, size_t bufsz)
 {
 	FILE *f;
 	char fname[BUFLEN];
@@ -52,6 +50,41 @@ char
 		buf[i--] = '\0';
 
 	return buf;
+}
+
+/* adapted from procd/utils.c -> should go to libubox */
+char *get_var_from_file(const char *filename, const char *name, char *out, int len)
+{
+	char line[1024], *c, *sptr;
+
+	int fd = open(filename, O_RDONLY);
+	if (fd == -1)
+		return NULL;
+
+	ssize_t r = read(fd, line, sizeof(line) - 1);
+	close(fd);
+
+	if (r <= 0)
+		return NULL;
+
+	line[r] = 0;
+
+	for (c = strtok_r(line, " \t\n", &sptr); c;
+			c = strtok_r(NULL, " \t\n", &sptr)) {
+		char *sep = strchr(c, '=');
+		if (sep == NULL)
+			continue;
+
+		ssize_t klen = sep - c;
+		if (strncmp(name, c, klen) || name[klen] != 0)
+			continue;
+
+		strncpy(out, &sep[1], len);
+		out[len-1] = '\0';
+		return out;
+	}
+
+	return NULL;
 }
 
 int block_file_identify(FILE *f, uint64_t offset)

--- a/libfstools/common.c
+++ b/libfstools/common.c
@@ -128,9 +128,19 @@ int block_file_identify(FILE *f, uint64_t offset)
 
 static bool use_f2fs(struct volume *v, uint64_t offset, const char *bdev)
 {
+	char typeparam[BUFLEN];
 	uint64_t size = 0;
 	bool ret = false;
 	int fd;
+
+	if (get_var_from_file("/proc/cmdline", "fstools_overlay_fstype", typeparam, sizeof(typeparam))) {
+		if (!strcmp("f2fs", typeparam))
+			return true;
+		else if (!strcmp("ext4", typeparam))
+			return false;
+		else if (strcmp("auto", typeparam))
+			ULOG_ERR("unsupported overlay filesystem type: %s\n", typeparam);
+	}
 
 	fd = open(bdev, O_RDONLY);
 	if (fd < 0)

--- a/libfstools/common.h
+++ b/libfstools/common.h
@@ -23,6 +23,7 @@
 
 int read_uint_from_file(char *dirname, char *filename, unsigned int *i);
 char *read_string_from_file(const char *dirname, const char *filename, char *buf, size_t bufsz);
+char *get_var_from_file(const char *filename, const char *name, char *out, int len);
 int block_file_identify(FILE *f, uint64_t offset);
 int block_volume_format(struct volume *v, uint64_t offset, const char *bdev);
 

--- a/libfstools/partname.c
+++ b/libfstools/partname.c
@@ -59,40 +59,6 @@ static int partname_volume_init(struct volume *v)
 	return block_volume_format(v, 0, p->parent_dev.devpathstr);
 }
 
-/* adapted from procd/utils.c -> should go to libubox */
-static char* get_var_from_file(const char* filename, const char* name, char* out, int len)
-{
-	char line[1024], *c, *sptr;
-	int fd = open(filename, O_RDONLY);
-	if (fd == -1)
-		return NULL;
-
-	ssize_t r = read(fd, line, sizeof(line) - 1);
-	close(fd);
-
-	if (r <= 0)
-		return NULL;
-
-	line[r] = 0;
-
-	for (c = strtok_r(line, " \t\n", &sptr); c;
-			c = strtok_r(NULL, " \t\n", &sptr)) {
-		char *sep = strchr(c, '=');
-		if (sep == NULL)
-			continue;
-
-		ssize_t klen = sep - c;
-		if (strncmp(name, c, klen) || name[klen] != 0)
-			continue;
-
-		strncpy(out, &sep[1], len);
-		out[len-1] = '\0';
-		return out;
-	}
-
-	return NULL;
-}
-
 static char *rootdevname(char *devpath) {
 	int l;
 

--- a/mount_root.c
+++ b/mount_root.c
@@ -22,6 +22,9 @@
 
 #include "libfstools/libfstools.h"
 #include "libfstools/volume.h"
+#include "libfstools/common.h"
+
+#define BUFLEN 64
 
 /*
  * Called in the early (PREINIT) stage, when we immediately need some writable
@@ -30,9 +33,16 @@
 static int
 start(int argc, char *argv[3])
 {
+	char dataparam[BUFLEN];
+	char *dataname = "rootfs_data";
 	struct volume *root;
-	struct volume *data = volume_find("rootfs_data");
+	struct volume *data;
 	struct stat s;
+
+	if (get_var_from_file("/proc/cmdline", "fstools_overlay_name", dataparam, sizeof(dataparam)))
+		dataname = dataparam;
+
+	data = volume_find(dataname);
 
 	if (!getenv("PREINIT") && stat("/tmp/.preinit", &s))
 		return -1;


### PR DESCRIPTION
hi @hauke @dangowrt @robimarko

Many devices support dual firmwares (`kermel`/`kernel_1`, `rootfs`/`rootfs_1`). However openwrt only supports dual firmwares on devices for which the overlay is stoted in the trailing part of the active rootfs partition. Devices with discreet overlay partitions (`rootfs_data`/`rootfs_data_1`) are not supported.

This change allows the bootloader to choose which `rootfs_data` partition to use, just like it could always choose which `rootfs`: via a kernel command line parameter.

For example, uboot can now specify `fstools_overlay_name=rootfs_data` or `fstools_overlay_name=rootfs_data_1`. This works for block devices, UBI and MTD, as the system delegates partition name resolution to the usual fstools driver stack.

For completeness, an `fstools_overlay_fstype=ext4`/`f2fs`/`auto` parameter is also included. This selects which filesystem to use when it is time to format the overlay anew.

thank you!

-----

this change has been tested to work properly in spectrum sax1v1k.