### PR TITLE
Support discard in "block" and "swapon"

### DIFF
--- a/block.c
+++ b/block.c
@@ -153,6 +153,7 @@ enum {
 	SWAP_LABEL,
 	SWAP_DEVICE,
 	SWAP_PRIO,
+	SWAP_DISCARD,
 	__SWAP_MAX
 };
 
@@ -162,6 +163,7 @@ static const struct blobmsg_policy swap_policy[__SWAP_MAX] = {
 	[SWAP_LABEL] = { .name = "label", .type = BLOBMSG_TYPE_STRING },
 	[SWAP_DEVICE] = { .name = "device", .type = BLOBMSG_TYPE_STRING },
 	[SWAP_PRIO] = { .name = "priority", .type = BLOBMSG_TYPE_INT32 },
+	[SWAP_DISCARD] = { .name = "discard", .type = BLOBMSG_TYPE_STRING },
 };
 
 static const struct uci_blob_param_list swap_attr_list = {
@@ -317,6 +319,7 @@ static int swap_add(struct uci_section *s)
 {
 	struct blob_attr *tb[__SWAP_MAX] = { 0 };
 	struct mount *m;
+	char *discard;
 
         blob_buf_init(&b, 0);
 	uci_to_blob(&b, s, &swap_attr_list);
@@ -331,10 +334,22 @@ static int swap_add(struct uci_section *s)
 	m->uuid = blobmsg_get_strdup(tb[SWAP_UUID]);
 	m->label = blobmsg_get_strdup(tb[SWAP_LABEL]);
 	m->device = blobmsg_get_basename(tb[SWAP_DEVICE]);
+	discard = blobmsg_get_strdup(tb[SWAP_DISCARD]);
+
 	if (tb[SWAP_PRIO])
 		m->prio = blobmsg_get_u32(tb[SWAP_PRIO]);
 	if (m->prio)
 		m->prio = ((m->prio << SWAP_FLAG_PRIO_SHIFT) & SWAP_FLAG_PRIO_MASK) | SWAP_FLAG_PREFER;
+
+	if (discard) {
+		if (!strcmp(discard, "yes") || !strcmp(discard, "1") || !strcmp(discard, "on"))
+			 m->prio |= SWAP_FLAG_DISCARD;
+		else if (!strcmp(discard, "pages"))
+			 m->prio |= (SWAP_FLAG_DISCARD | SWAP_FLAG_DISCARD_PAGES);
+		else if (!strcmp(discard, "once"))
+			 m->prio |= (SWAP_FLAG_DISCARD | SWAP_FLAG_DISCARD_ONCE);
+	} else
+		 m->prio |= SWAP_FLAG_DISCARD;
 
 	if ((!tb[SWAP_ENABLE]) || blobmsg_get_u32(tb[SWAP_ENABLE])) {
 		/* store complete swap path */

--- a/block.c
+++ b/block.c
@@ -1883,7 +1883,7 @@ static int main_swapon(int argc, char **argv)
 			list_for_each_entry(pr, &devices, list) {
 				if (strcmp(pr->type, "swap"))
 					continue;
-				if (swapon(pr->dev, 0))
+				if (swapon(pr->dev, SWAP_FLAG_DISCARD))
 					ULOG_ERR("failed to swapon %s\n", pr->dev);
 			}
 			return 0;

--- a/block.c
+++ b/block.c
@@ -52,6 +52,16 @@
 #include "libubi/libubi.h"
 #endif
 
+#ifndef SWAP_FLAG_DISCARD
+#define SWAP_FLAG_DISCARD 0x10000
+#endif
+#ifndef SWAP_FLAG_DISCARD_ONCE
+#define SWAP_FLAG_DISCARD_ONCE 0x20000
+#endif
+#ifndef SWAP_FLAG_DISCARD_PAGES
+#define SWAP_FLAG_DISCARD_PAGES 0x40000
+#endif
+
 enum {
 	TYPE_MOUNT,
 	TYPE_SWAP,


### PR DESCRIPTION
SSD drives are quite common, so following their rules (discarding the unused blocks) can extend their life time. In addition, even if the device doesn't support discard, kernel can always "downgrade" the flags.

This PR adds discard options to `block` by extending the `swap` entries of `fstab` config with the `discard` parameter that provides full control over the discard feature.
`swapon` is another entry point for swap activation, so it gets an extra flag `-d`. The implementation is inspired by busybox.
