### PR TITLE
overlay: add support for F2FS compression

### DIFF
--- a/libfstools/common.c
+++ b/libfstools/common.c
@@ -154,10 +154,21 @@ static bool use_f2fs(struct volume *v, uint64_t offset, const char *bdev)
 	return ret;
 }
 
+static bool use_f2fs_compression(void)
+{
+	char typeparam[BUFLEN];
+
+	if (!get_var_from_file("/proc/cmdline", "fstools_overlay_compression_type",
+			       typeparam, sizeof(typeparam)))
+		return false;
+
+	return typeparam[0] && strcmp(typeparam, "none");
+}
+
 int block_volume_format(struct volume *v, uint64_t offset, const char *bdev)
 {
 	int ret = 0;
-	char str[128];
+	char str[256];
 	unsigned int skip_blocks = 0;
 	int fd;
 	__u32 deadc0de;
@@ -205,10 +216,17 @@ int block_volume_format(struct volume *v, uint64_t offset, const char *bdev)
 		}
 do_format:
 		ULOG_INFO("overlay filesystem in %s has not been formatted yet\n", v->blk);
-		if (use_f2fs(v, offset, bdev))
-			snprintf(str, sizeof(str), "mkfs.f2fs -q -f -l rootfs_data %s", v->blk);
-		else
+		if (use_f2fs(v, offset, bdev)) {
+			if (use_f2fs_compression()) {
+				ULOG_INFO("f2fs overlay compression enabled\n");
+				snprintf(str, sizeof(str),
+					 "mkfs.f2fs -q -f -O extra_attr,compression -l rootfs_data %s", v->blk);
+			} else {
+				snprintf(str, sizeof(str), "mkfs.f2fs -q -f -l rootfs_data %s", v->blk);
+			}
+		} else {
 			snprintf(str, sizeof(str), "mkfs.ext4 -q -F -L rootfs_data %s", v->blk);
+		}
 
 		ret = system(str);
 		break;

--- a/libfstools/overlay.c
+++ b/libfstools/overlay.c
@@ -29,6 +29,7 @@
 
 #include "libfstools.h"
 #include "volume.h"
+#include "common.h"
 
 #ifndef GLOB_ONLYDIR
 #define GLOB_ONLYDIR 0x100
@@ -284,6 +285,26 @@ static char *overlay_fs_name(int type)
 	}
 }
 
+static const char *overlay_mount_options(char *fstype)
+{
+	char typeparam[64];
+
+	if (!strcmp(fstype, "f2fs") &&
+	    get_var_from_file("/proc/cmdline", "fstools_overlay_compression_type",
+			      typeparam, sizeof(typeparam))) {
+		if (!strcmp(typeparam, "zstd")) {
+			ULOG_INFO("mounting f2fs overlay with zstd level 3 compression\n");
+			return "compress_algorithm=zstd:3";
+		}
+	}
+
+#ifdef OVL_MOUNT_COMPRESS_ZLIB
+	return "compr=zlib";
+#else
+	return NULL;
+#endif
+}
+
 int
 jffs2_switch(struct volume *v)
 {
@@ -347,24 +368,27 @@ jffs2_switch(struct volume *v)
 static int overlay_mount_fs(struct volume *v, const char *overlay_mp)
 {
 	char *fstype = overlay_fs_name(volume_identify(v));
+	const char *options = overlay_mount_options(fstype);
+#ifdef OVL_MOUNT_FULL_ACCESS_TIME
+	unsigned long mount_flags = MS_RELATIME;
+#else
+	unsigned long mount_flags = MS_NOATIME;
+#endif
 
 	if (mkdir(overlay_mp, 0755)) {
 		ULOG_ERR("failed to mkdir /tmp/overlay: %m\n");
 		return -1;
 	}
 
-	if (mount(v->blk, overlay_mp, fstype,
-#ifdef OVL_MOUNT_FULL_ACCESS_TIME
-		MS_RELATIME,
-#else
-		MS_NOATIME,
-#endif
-#ifdef OVL_MOUNT_COMPRESS_ZLIB
-		"compr=zlib"
-#else
-		NULL
-#endif
-		)) {
+	if (mount(v->blk, overlay_mp, fstype, mount_flags, options)) {
+		if (!strcmp(fstype, "f2fs") && options) {
+			ULOG_WARN("failed to mount f2fs overlay with compression, "
+				  "retrying without compression\n");
+
+			if (!mount(v->blk, overlay_mp, fstype, mount_flags, NULL))
+				return 0;
+		}
+
 		ULOG_ERR("failed to mount -t %s %s /tmp/overlay: %m\n",
 		         fstype, v->blk);
 		return -1;


### PR DESCRIPTION
This PR adds support for using F2FS compression if F2FS is used as the overlay FS.
Its done in 2 steps, first if `fstools_overlay_compression_type` is passed in cmdline and its not empty or `none` it will format the F2FS overlay with XATTR and compression support.

And then when `fstools_overlay_compression_type=zstd` F2FS overlay will be mounted with ZSTD compression and level 3 as a good default.